### PR TITLE
Fix Semi crash (#413)

### DIFF
--- a/Proteomics/ProteolyticDigestion/DigestionParams.cs
+++ b/Proteomics/ProteolyticDigestion/DigestionParams.cs
@@ -93,8 +93,8 @@ namespace Proteomics.ProteolyticDigestion
             if (SearchModeType == CleavageSpecificity.None) //nonspecific searches, which might have a specific protease
             {
                 Protease = FragmentationTerminus == FragmentationTerminus.N ?
-                    ProteaseDictionary.Dictionary["singleN"] :
-                    ProteaseDictionary.Dictionary["singleC"];
+                   ProteaseDictionary.Dictionary["singleN"] :
+                   ProteaseDictionary.Dictionary["singleC"];
             }
         }
     }

--- a/Proteomics/ProteolyticDigestion/ProteinDigestion.cs
+++ b/Proteomics/ProteolyticDigestion/ProteinDigestion.cs
@@ -85,7 +85,7 @@ namespace Proteomics.ProteolyticDigestion
                         }
                         else if (DigestionParams.FragmentationTerminus == FragmentationTerminus.N)
                         {
-                            peptides.Add(new ProteolyticPeptide(protein, 2, 2 + MaxPeptideLength + MaxPeptideLength, MaximumMissedCleavages, CleavageSpecificity.Semi, "semi"));
+                            peptides.Add(new ProteolyticPeptide(protein, 2, 2 + MaxPeptideLength, MaximumMissedCleavages, CleavageSpecificity.Semi, "semi"));
                         }
                         else //It has to be FragmentationTerminus.C //make something with the maximum length and fixed C
                         {

--- a/Test/TestPeptideWithSetMods.cs
+++ b/Test/TestPeptideWithSetMods.cs
@@ -1,4 +1,5 @@
-﻿using NUnit.Framework;
+﻿using Chemistry;
+using NUnit.Framework;
 using Proteomics;
 using Proteomics.Fragmentation;
 using Proteomics.ProteolyticDigestion;
@@ -7,6 +8,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using UsefulProteomicsDatabases;
 
 namespace Test
 {
@@ -33,6 +35,18 @@ namespace Test
             Assert.That(!pep1.DigestionParams.Protease.Equals(pep2.DigestionParams.Protease));
             Assert.That(!pep1.Equals(pep2));
             Assert.That(!pep1.GetHashCode().Equals(pep2.GetHashCode()));
+        }
+
+        [Test]
+        public static void TestSemiFewCleavages()
+        {
+            Protein protein = new Protein("MQLLRCFSIFSVIASVLAQELTTICEQIPSPTLESTPYSLSTTTILANGKAMQGVFEYYKSVTFVSNCGSHPSTTSKGSPINTQYVF", "P32781");
+            DigestionParams nParams = new DigestionParams("trypsin", 2, 7, 50, searchModeType: CleavageSpecificity.Semi, fragmentationTerminus: FragmentationTerminus.N);
+            DigestionParams cParams = new DigestionParams("trypsin", 2, 7, 50, searchModeType: CleavageSpecificity.Semi, fragmentationTerminus: FragmentationTerminus.C);
+
+            //Unit test is not crashing
+            protein.Digest(nParams, null, null).ToList();
+            protein.Digest(cParams, null, null).ToList();
         }
 
         [Test]


### PR DESCRIPTION
* Update DigestionParams for speedy nonspecific enzyme search

* Save terminus in digestion

* revert unit test changes and leave a note for the future

* Add search mode type and original protease to digest params for fast nonspecific search

* Change semi proteases to detail if they are full or specific peptides. Add cleavage specificty to proteolyticpeptide to record this.

* fix double account

* update unit test pwsm initializer

* Beefy unit test and bug fixes

* Update so that non-specific are non-specific

* update peptide description with cleavage specificity

* Comments, renames, removal of Linq

* Unit test comments

* refactor unit test and singleN/C termini

* Update unit test without testcase and auxillary method

* SpeedyNonspecific fix to digetionParams to remove terminus confusion

* Crash fix semi specific